### PR TITLE
对刷熟练度时间过长/滑块判断的优化

### DIFF
--- a/repo/js/AEscoffier_chef/main.js
+++ b/repo/js/AEscoffier_chef/main.js
@@ -7545,6 +7545,7 @@
         let select_cooking_mode;
         let extraTime;
         let check_quality;
+        let add_times_noscroll;
         try {
             food_choice_single_select = typeof(settings.food_choice_single_select) === "undefined" ? "无(默认)": settings.food_choice_single_select;
         } catch(error) {
@@ -7803,6 +7804,12 @@
             log.error(`check_quality 读取错误: ${error}`);
             return false;
         }
+        try {
+            add_times_noscroll = typeof(settings.add_times_noscroll) === "undefined" ? false: settings.add_times_noscroll;
+        } catch(error) {
+            log.error(`add_times_noscroll 读取错误: ${error}`);
+            return false;
+        }
         return {
             "food_choice_single_select": food_choice_single_select,
             "food_Max_HP_Boost": food_Max_HP_Boost,
@@ -7846,7 +7853,8 @@
             "food_character_num": food_character_num,
             "select_cooking_mode": select_cooking_mode,
             "extra_time": extraTime,
-            "check_quality": check_quality
+            "check_quality": check_quality,
+            "add_times_noscroll": add_times_noscroll,
         }
     }
 
@@ -8055,6 +8063,7 @@
         task_dic["other_settings"]["cooking_mode"] = setting_dic["select_cooking_mode"];
         task_dic["other_settings"]["extra_time"] = setting_dic["extra_time"];
         task_dic["other_settings"]["check_quality"] = setting_dic["check_quality"];
+        task_dic["other_settings"]["add_times_noscroll"] = setting_dic["add_times_noscroll"];
 
         return task_dic;
     }
@@ -8453,16 +8462,18 @@
             log.error("当前不处于料理制作界面...");
             return false;
         }
-        // 滑动到顶部
-        await scroll_pages_main("up", 10);
-        for (let i = 0; i < 30; i++) {
-            let food_choice = await select_food_by_fullname(await deal_string(food_name));
-            if (food_choice) {
-                return true;
-            } else {
-                let scroll_result = await scroll_pages_main("down", 1);
-                if (!scroll_result) {
-                    break;
+        if (!setting_dic["other_settings"]["add_times_noscroll"]){
+            // 滑动到顶部
+            await scroll_pages_main("up", 10);
+            for (let i = 0; i < 30; i++) {
+                let food_choice = await select_food_by_fullname(await deal_string(food_name));
+                if (food_choice) {
+                    return true;
+                } else {
+                    let scroll_result = await scroll_pages_main("down", 1);
+                    if (!scroll_result) {
+                        break;
+                    }
                 }
             }
         }
@@ -8491,16 +8502,18 @@
             log.error("当前不处于烹饪界面...");
             return false;
         }
-        // 滑动到顶部
-        await scroll_pages_cooking("up", 15);
-        for (let i = 0; i < 10; i++) {
-            let character_choice = await select_character_by_fullname(name);
-            if (character_choice) {
-                return true;
-            } else {
-                let scroll_result = await scroll_pages_main("down", 1);
-                if (!scroll_result) {
-                    break;
+        if (!setting_dic["other_settings"]["add_times_noscroll"]){
+            // 滑动到顶部
+            await scroll_pages_cooking("up", 15);
+            for (let i = 0; i < 10; i++) {
+                let character_choice = await select_character_by_fullname(name);
+                if (character_choice) {
+                    return true;
+                } else {
+                    let scroll_result = await scroll_pages_main("down", 1);
+                    if (!scroll_result) {
+                        break;
+                    }
                 }
             }
         }

--- a/repo/js/AEscoffier_chef/settings.json
+++ b/repo/js/AEscoffier_chef/settings.json
@@ -228,6 +228,11 @@
     "options": ["优先自动烹饪(默认)", "优先手动烹饪", "刷满熟练度(将选择的可烹饪食物熟练度刷满)"]
   },
   {
+    "name": "add_times_noscroll",
+    "type": "checkbox",
+    "label": "刷熟练度跳过滑块"
+  },
+  {
     "name": "extraTime",
     "type": "input-text",
     "label": "额外的烹饪时间(ms)"


### PR DESCRIPTION
1.主代码增加对跳过滑块选项的判断
2.配置文件增加勾选框

> 纯为了效率直接改的 没细看代码逻辑 最优解应该是如果选择全部食材 且选择刷满熟练度 自动跳过滑块验证(原神有过滤未满熟练度功能